### PR TITLE
toml switch for latest alacritty compatability

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,11 +4,11 @@
 
 ![Image of a terminal displaying the Snazzy theme colors](screenshot.png)
 
-Last update for version: `0.4.2`
+Last update for version: `0.13.0`
 
 ## Install
 
-- Copy the contents of `snazzy.yml` to your `alacritty.yml` configuration file.
+- Copy the contents of `snazzy.toml` to your `alacritty.toml` configuration file (or `.yml` for older alacritty versions).
 
 ## Related
 

--- a/snazzy.toml
+++ b/snazzy.toml
@@ -1,0 +1,33 @@
+[colors]
+draw_bold_text_with_bright_colors = true
+
+[colors.bright]
+black = "#686868"
+blue = "#57c7ff"
+cyan = "#9aedfe"
+green = "#5af78e"
+magenta = "#ff6ac1"
+red = "#ff5c57"
+white = "#eff0eb"
+yellow = "#f3f99d"
+
+[colors.cursor]
+cursor = "#97979b"
+
+[colors.normal]
+black = "#282a36"
+blue = "#57c7ff"
+cyan = "#9aedfe"
+green = "#5af78e"
+magenta = "#ff6ac1"
+red = "#ff5c57"
+white = "#f1f1f0"
+yellow = "#f3f99d"
+
+[colors.primary]
+background = "#282a36"
+foreground = "#eff0eb"
+
+[colors.selection]
+background = "#feffff"
+text = "#282a36"


### PR DESCRIPTION
From the latest alacritty update https://alacritty.org/changelog_0_13_0.html#Changed, `Configuration file now uses TOML instead of YAML`.

I left the yaml file for backwards compatibility with people who haven't picked up the update, maybe can remove at some point.